### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ All the code responsible for merging into the system UI is stored in `literm.qmd
 
 The font I added instead of the system default is [hack](https://github.com/source-foundry/Hack)
 
-To build, run `qmake .; make` after setting up the XOVI_ROOT environmental variable, and sourcing the toolchain's env. file.
+To build, run `qmake .; make` after setting up the XOVI_REPO environmental variable, and sourcing the toolchain's env. file.
 
 Since this project modifies the rM's UI, it is not version agnostic. To update from one version to another, change the values in `literm.qmd`.
 


### PR DESCRIPTION
I think this is supposed to be XOVI_REPO.

I think this was causing problems for me trying to build this.